### PR TITLE
Find and use proper insertion point for DLL

### DIFF
--- a/src/services/registry.js
+++ b/src/services/registry.js
@@ -533,7 +533,8 @@ class RegistryService {
       }
 
       try {
-        const prevPollId = 0
+        const prevPollId =
+          await pify(plcr.getInsertPointForNumTokens.call)(this.getAccount(), votes);
         const hash = saltHashVote(voteOption, salt)
 
         await plcr.commit({pollId: challengeId, hash, tokens: votes, prevPollId})


### PR DESCRIPTION
If you just use zero all the time, it'll cause a lot of tricky bugs in all sorts of places. Mostly around votes failing.